### PR TITLE
Update mpc download link

### DIFF
--- a/defs.sh
+++ b/defs.sh
@@ -233,7 +233,7 @@ gccprereqs() {
 
     if [ ! -e gcc-$GCC_VERSION/mpc ]
     then
-        fetchextract http://www.multiprecision.org/mpc/download/ mpc-$MPC_VERSION .tar.gz
+        fetchextract https://ftp.gnu.org/gnu/mpc/ mpc-$MPC_VERSION .tar.gz
         mv mpc-$MPC_VERSION gcc-$GCC_VERSION/mpc
     fi
 }


### PR DESCRIPTION
The link provided in defs.sh to download mpc is not working (Error 500 Internal Server Error). However, the link proposed in this change does.