### PR TITLE
Use ftp.gnu.org to download GNU MPc

### DIFF
--- a/defs.sh
+++ b/defs.sh
@@ -233,7 +233,7 @@ gccprereqs() {
 
     if [ ! -e gcc-$GCC_VERSION/mpc ]
     then
-        fetchextract http://www.multiprecision.org/mpc/download/ mpc-$MPC_VERSION .tar.gz
+        fetchextract https://ftp.gnu.org/gnu/mpc/ mpc-$MPC_VERSION .tar.gz
         mv mpc-$MPC_VERSION gcc-$GCC_VERSION/mpc
     fi
 }


### PR DESCRIPTION
http://www.multiprecision.org/mpc/download/ is down.
We should use the GNU server for downloading the GNU MPC library.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>